### PR TITLE
Fix jitpack problems

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,5 @@
 jdk:
   - openjdk17
 before_install:
-  - sdk install java 17.0.1-open
-  - sdk use java 17.0.1-open
+  - sdk install java 17.0.2-open
+  - sdk use java 17.0.2-open

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,1 +1,5 @@
-jdk: openjdk17
+jdk:
+  - openjdk17
+before_install:
+  - sdk install java 17.0.1-open
+  - sdk use java 17.0.1-open


### PR DESCRIPTION
Hello! :wave: 

Jitpack previously wasn't using JDK 17 to build your repository. The fix is to add a few lines to before_install, as shown. The fabric-loom plugin doesn't like Java 8 (the default) so builds will fail without this change. 