### PR TITLE
Allow wider range of 1.19 versions of Minecraft

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,6 +23,6 @@
   ],
   "depends": {
     "fabricloader": ">=0.13.3",
-    "minecraft": "1.19"
+    "minecraft": "~1.19.0"
   }
 }


### PR DESCRIPTION
This constraint ensures that Renderer can run under 1.19.1 (and really any 1.19 version).

I have tested it with my mod and it works just fine on 1.19.1 without any changes except to the constraint.