### PR TITLE
Add library badge for mod menu

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,5 +27,10 @@
   "depends": {
     "fabricloader": ">=0.14.12",
     "minecraft": "1.20.*"
+  },
+  "custom": {
+    "modmenu": {
+      "badges": ["library"]
+    }
   }
 }


### PR DESCRIPTION
Adds mod menu compatibility, this time with the metadata only. This library will now show as a library in mod menu.  
Should not cause any issues since this does not add a dependency, only metadata.

Supercedes #18 