### PR TITLE
change: cache GL viewport

### DIFF
--- a/src/main/java/me/x150/renderer/mixin/GameRendererMixin.java
+++ b/src/main/java/me/x150/renderer/mixin/GameRendererMixin.java
@@ -11,6 +11,7 @@ import me.x150.renderer.util.RendererUtils;
 import net.minecraft.client.render.*;
 import net.minecraft.client.util.math.MatrixStack;
 import org.joml.Matrix4f;
+import org.lwjgl.opengl.GL11;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
@@ -29,6 +30,8 @@ public abstract class GameRendererMixin {
 		RendererUtils.lastProjMat.set(RenderSystem.getProjectionMatrix());
 		RendererUtils.lastModMat.set(RenderSystem.getModelViewMatrix());
 		RendererUtils.lastWorldSpaceMatrix.set(matrix.peek().getPositionMatrix());
+        GL11.glGetIntegerv(GL11.GL_VIEWPORT, RendererUtils.lastViewport);
+
 		RenderEvents.WORLD.invoker().rendered(matrix);
 		Renderer3d.renderFadingBlocks(matrix);
 

--- a/src/main/java/me/x150/renderer/util/RendererUtils.java
+++ b/src/main/java/me/x150/renderer/util/RendererUtils.java
@@ -41,6 +41,8 @@ public class RendererUtils {
 	public static final Matrix4f lastModMat = new Matrix4f();
 	@ApiStatus.Internal
 	public static final Matrix4f lastWorldSpaceMatrix = new Matrix4f();
+    @ApiStatus.Internal
+    public static final int[] lastViewport = new int[4];
 
 	private static final FastMStack empty = new FastMStack();
 	private static final MinecraftClient client = MinecraftClient.getInstance();
@@ -256,8 +258,6 @@ public class RendererUtils {
 	public static Vec3d worldSpaceToScreenSpace(@NonNull Vec3d pos) {
 		Camera camera = client.getEntityRenderDispatcher().camera;
 		int displayHeight = client.getWindow().getHeight();
-		int[] viewport = new int[4];
-		GL11.glGetIntegerv(GL11.GL_VIEWPORT, viewport);
 		Vector3f target = new Vector3f();
 
 		double deltaX = pos.x - camera.getPos().x;
@@ -271,7 +271,7 @@ public class RendererUtils {
 		Matrix4f matrixModel = new Matrix4f(lastModMat);
 
 		matrixProj.mul(matrixModel)
-				.project(transformedCoordinates.x(), transformedCoordinates.y(), transformedCoordinates.z(), viewport,
+				.project(transformedCoordinates.x(), transformedCoordinates.y(), transformedCoordinates.z(), lastViewport,
 						target);
 
 		return new Vec3d(target.x / client.getWindow().getScaleFactor(),
@@ -309,8 +309,6 @@ public class RendererUtils {
 		Camera camera = client.getEntityRenderDispatcher().camera;
 		int displayHeight = client.getWindow().getScaledHeight();
 		int displayWidth = client.getWindow().getScaledWidth();
-		int[] viewport = new int[4];
-		GL11.glGetIntegerv(GL11.GL_VIEWPORT, viewport);
 		Vector3f target = new Vector3f();
 
 		Matrix4f matrixProj = new Matrix4f(lastProjMat);
@@ -318,8 +316,8 @@ public class RendererUtils {
 
 		matrixProj.mul(matrixModel)
 				.mul(lastWorldSpaceMatrix)
-				.unproject((float) x / displayWidth * viewport[2],
-						(float) (displayHeight - y) / displayHeight * viewport[3], (float) d, viewport, target);
+				.unproject((float) x / displayWidth * lastViewport[2],
+						(float) (displayHeight - y) / displayHeight * lastViewport[3], (float) d, lastViewport, target);
 
 		return new Vec3d(target.x, target.y, target.z).add(camera.getPos());
 	}


### PR DESCRIPTION
Getting the viewport from GL is a JNI call, which is expensive. Using `worldSpaceToScreenSpace` or `screenSpaceToWorldSpace` multiple times per frame can make a serious impact on performance:

The examples below don't use the Renderer lib directly, but rather a copy of `worldSpaceToScreenSpace` slightly adjusted for my project's needs

No caching:
![image](https://github.com/user-attachments/assets/9896cd42-8a52-4193-b82f-25ef83cac7b9)

Caching:
![image](https://github.com/user-attachments/assets/64ff29fb-bf5e-43f3-ac8a-28decea38053)